### PR TITLE
Create workflow to build launcher (Windows only)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,12 +44,12 @@ jobs:
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
-        tools: 'tools_opensslv3_x64'
+        tools: 'tools_opensslv3_x64 tools_cmake tools_ninja'
 
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DOPENSSL_ROOT_DIR=${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64
+      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DOPENSSL_ROOT_DIR=${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64 -G "Ninja Multi-Config"
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,22 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'Build type'
+        required: true
+        default: 'Release'
+        type: choice
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - MinSizeRel
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: ${{ github.event.inputs.build_type }}
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: launcher-${{ github.ref_name }}-win64
-        path: ${{ github.workspace }}/dist/bin/*
+        path: ${{ github.workspace }}/dist/*
 
     - name: Packing
       if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DOPENSSL_ROOT_DIR=${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64 -G "Ninja Multi-Config"
+      run: cmake -B ${{ github.workspace }}/build -DOPENSSL_ROOT_DIR=${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64 -G "Ninja Multi-Config"
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,8 @@ jobs:
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: windows-latest
-
+    env:
+      QT6_INSTALL_DIR: ${{ github.workspace }}
     steps:
     - uses: actions/checkout@v4
 
@@ -45,11 +46,12 @@ jobs:
         target: 'desktop'
         arch: 'win64_mingw'
         tools: 'tools_opensslv3_x64 tools_cmake tools_ninja tools_mingw1310'
+        dir: ${{ env.QT6_INSTALL_DIR }}
 
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{ github.workspace }}/build -DOPENSSL_ROOT_DIR=${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64 -G "Ninja Multi-Config"
+      run: cmake -B ${{ github.workspace }}/build -DOPENSSL_ROOT_DIR=${{ env.QT6_INSTALL_DIR }}/Qt/Tools/OpenSSLv3/Win_x64 -G "Ninja Multi-Config"
 
     - name: Build
       # Build your program with the given configuration
@@ -66,16 +68,18 @@ jobs:
 
     # Copy DLLs needed to run launcher
     - name: Copy libraries (OpenSSL)
-      working-directory: ${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64/bin/
+      working-directory: ${{ env.QT6_INSTALL_DIR }}/Qt/Tools/OpenSSLv3/Win_x64/bin/
       run: cp libcrypto-3-x64.dll,libssl-3-x64.dll ${{ github.workspace }}/dist/bin/
-
-    - name: Packing
-      run: Compress-Archive -Path ${{ github.workspace }}/dist/* -Destination ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        path: ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
+        name: launcher-${{ github.ref_name }}-win64
+        path: ${{ github.workspace }}/dist/bin/*
+
+    - name: Packing
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: Compress-Archive -Path ${{ github.workspace }}/dist/* -Destination ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
 
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,11 +58,11 @@ jobs:
           OPENSSL_ROOT_DIR=${{ env.QT6_INSTALL_DIR }}/Qt/Tools/OpenSSLv3/Win_x64
         build-args: '--config ${{ env.BUILD_TYPE }} --parallel'
 
-    - name: Test Project
-      uses: threeal/ctest-action@v1.1.0
-      with:
-        test-dir: ${{ github.workspace }}/build
-        build-config: ${{ env.BUILD_TYPE }}
+    - name: Test
+      working-directory: ${{ github.workspace }}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{ env.BUILD_TYPE }}
 
     - name: Install
       run: cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
-        tools: 'tools_opensslv3_x64 tools_cmake tools_ninja'
+        tools: 'tools_opensslv3_x64 tools_cmake tools_ninja tools_mingw1310'
 
     - name: Configure
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+# This starter workflow is for a CMake project running on a single platform. There is a different starter workflow if you need cross-platform coverage.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-multi-platform.yml
+name: Publish launcher
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        aqtversion: '==3.1.*'
+        version: '6.8.1'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_msvc2022_64'
+        tools: 'tools_opensslv3_x64'
+
+    - name: Configure
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DOPENSSL_ROOT_DIR=${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+
+    - name: Test
+      working-directory: ${{ github.workspace }}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{ env.BUILD_TYPE }}
+
+    - name: Install
+      run: cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/dist
+
+    # Copy DLLs needed to run launcher
+    - name: Copy libraries (OpenSSL)
+      working-directory: ${{ env.IQTA_TOOLS }}/OpenSSLv3/Win_x64/bin/
+      run: cp libcrypto-3-x64.dll,libssl-3-x64.dll ${{ github.workspace }}/dist/bin/
+
+    - name: Packing
+      run: Compress-Archive -Path ${{ github.workspace }}/dist/* -Destination ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
+        fail_on_unmatched_files: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,20 +48,21 @@ jobs:
         tools: 'tools_opensslv3_x64 tools_cmake tools_ninja tools_mingw1310'
         dir: ${{ env.QT6_INSTALL_DIR }}
 
-    - name: Configure
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{ github.workspace }}/build -DOPENSSL_ROOT_DIR=${{ env.QT6_INSTALL_DIR }}/Qt/Tools/OpenSSLv3/Win_x64 -G "Ninja Multi-Config"
+    - name: CMake Action
+      uses: threeal/cmake-action@v2
+      with:
+        source-dir: ${{ github.workspace }}
+        build-dir: ${{ github.workspace }}/build
+        generator: 'Ninja Multi-Config'
+        options: |
+          OPENSSL_ROOT_DIR=${{ env.QT6_INSTALL_DIR }}/Qt/Tools/OpenSSLv3/Win_x64
+        build-args: '--config ${{ env.BUILD_TYPE }} --parallel'
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
-
-    - name: Test
-      working-directory: ${{ github.workspace }}/build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{ env.BUILD_TYPE }}
+    - name: Test Project
+      uses: threeal/ctest-action@v1.1.0
+      with:
+        test-dir: ${{ github.workspace }}/build
+        build-config: ${{ env.BUILD_TYPE }}
 
     - name: Install
       run: cmake --install ${{ github.workspace }}/build --prefix ${{ github.workspace }}/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,6 @@ on:
   push:
     tags:
       - "v*.*.*"
-  pull_request:
-    branches: [master, development]
-
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+  pull_request:
+    branches: [master, development]
+
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,14 @@ jobs:
     - name: Packing
       run: Compress-Archive -Path ${{ github.workspace }}/dist/* -Destination ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
 
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
+
     - name: Release
       uses: softprops/action-gh-release@v2
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
         files: ${{ github.workspace }}/launcher-${{ github.ref_name }}-win64.zip
         fail_on_unmatched_files: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         version: '6.8.1'
         host: 'windows'
         target: 'desktop'
-        arch: 'win64_msvc2022_64'
+        arch: 'win64_mingw'
         tools: 'tools_opensslv3_x64 tools_cmake tools_ninja tools_mingw1310'
 
     - name: Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Concurrent)
+find_package(OpenSSL 3 REQUIRED SSL Crypto)
 
 qt_standard_project_setup()
 qt_add_executable(launcher
@@ -30,8 +31,8 @@ target_link_libraries(launcher PUBLIC
         Qt::Gui
         Qt::Widgets
         Qt::Concurrent
-        ssl
-        crypto
+        OpenSSL::SSL
+        OpenSSL::Crypto
 )
 
 set_target_properties(launcher PROPERTIES


### PR DESCRIPTION
Clones repo, installs Qt 6.8.1 with OpenSSLv3 x64 tool. Configures, builds, tests, installs, copies OpenSSL DLLs, packs and then finally uploads on tag release. Not the best but a working example and a starting ground to get the launcher building. The OpenSSL DLL step was necessary to fix libcrypto-3-x64.dll error on launching the launcher.

Can make it possible for manual invocation of triggering this workflow with uploading artifacts.

Launcher runs successfully with dependencies bundled.

Open to suggestions.

![image](https://github.com/user-attachments/assets/cae365c0-9ba7-48b1-b8c4-bd1419c99ba9)
